### PR TITLE
Feat(showUserView): Add flow control in showUserView to allow admin to see others users profiles

### DIFF
--- a/src/AppRoutes.jsx
+++ b/src/AppRoutes.jsx
@@ -19,7 +19,7 @@ const AppRouter = function AppRouter() {
         <Route path="/" element={<LandingPage />} />
         <Route path="/projects/:id" element={<ShowProject />} />
         <Route path="projectregister" element={<RegisterProject />} />
-        <Route path="/profile" element={<ShowUser />} />
+        <Route path="/users/:id" element={<ShowUser />} />
         <Route path="/register" element={<RegisterUserPage />} />
         <Route path="/user/update" element={<UpdaterUserPage />} />
         <Route path="/users/:id/projects" element={<MyProjects />} />

--- a/src/components/navbar/Navbar.jsx
+++ b/src/components/navbar/Navbar.jsx
@@ -28,7 +28,7 @@ function Navbar() {
             <NavLink exact to="/tables" activeClassName="activeClicked">
               <CDBSidebarMenuItem icon="hand-holding-usd">Proyectos financiados</CDBSidebarMenuItem>
             </NavLink>
-            <NavLink exact to="/profile" activeClassName="activeClicked">
+            <NavLink exact to={`/users/${currentUser.id}`} activeClassName="activeClicked">
               <CDBSidebarMenuItem icon="chart-line">Mi información financiera</CDBSidebarMenuItem>
             </NavLink>
           </CDBSidebarMenu>
@@ -38,7 +38,7 @@ function Navbar() {
           <div className="sidebar-btn-wrapper" style={{ padding: '20px 5px' }}>
             {currentUser ? (
               <>
-                <NavLink exact to="/profile" activeClassName="activeClicked">
+                <NavLink exact to={`/users/${currentUser.id}`} activeClassName="activeClicked">
                   <CDBSidebarMenuItem>Mi perfil</CDBSidebarMenuItem>
                 </NavLink>
                 <NavLink exact to="/hero404" activeClassName="activeClicked">

--- a/src/components/user/updateButton.jsx
+++ b/src/components/user/updateButton.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Button from 'react-bootstrap/Button';
-import './userShow.css';
+import './UserShow.css';
 
 export function ButtonUpdatingUser() {
   const printHelloWorld = () => {

--- a/src/components/user/userShow.jsx
+++ b/src/components/user/userShow.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import './userShow.css';
+import './UserShow.css';
 
 export function UserShow({
   name, rut, description, email,

--- a/src/views/user/userShow/ShowUser.jsx
+++ b/src/views/user/userShow/ShowUser.jsx
@@ -1,37 +1,113 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 // import { useNavigate } from 'react-router-dom';
 // import { useNavigate, Link } from 'react-router-dom';
 import useAuth from '../../../hooks/useAuth';
 import Navbar from '../../../components/navbar/Navbar';
 import './ShowUser.css';
-import { UserShow } from '../../../components/user/userShow';
-import { ButtonUpdatingUser } from '../../../components/user/updateButton';
+import { UserShow } from '../../../components/user/UserShow';
+import { ButtonUpdatingUser } from '../../../components/user/UpdateButton';
 import { ButtonBack } from '../../../components/buttons/buttonBack/ButtonBack';
+import Loading from '../../../components/loading/Loading';
 
 function ShowUser() {
   const { currentUser } = useAuth();
+  const { id } = useParams();
+  const [user, setUser] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
   //   const navigate = useNavigate();
   return (
-    <div>
+    (currentUser?.isAdmin == true) ? (
+      useEffect(() => {
+        setLoading(true);
+        const requestOptions = {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${currentUser?.token}`,
+          },
+        };
+        fetch(`${process.env.REACT_APP_API_URL}/users/${id}`, requestOptions)
+          .then(async (response) => {
+            if (!response.ok) {
+              setError(true);
+              return null;
+            }
+            const respuesta = await response.json();
+            setUser(respuesta);
+            return respuesta;
+          })
+          .catch(() => { setError(true); })
+          .finally(() => setLoading(false));
+      }, []),
+      (loading==true) ? (
+          <Loading />
+      ) : (
+        <>
+        </>
+      ),
+      (error) ? (
+        <div className="flex-inside">
+          <h2>
+            Error
+            {error}
+          </h2>
+        </div>
+          ) : (
+        <div>
+        <div className="grid-container-show-user">
+          <div>
+            <Navbar />
+          </div>
+          <div className="flex-show-user">
+            <UserShow
+              name={user?.name}
+              description={user?.description}
+              rut={user?.rut}
+              money={user?.money}
+              email={user?.email}
+            />
+            <ButtonUpdatingUser />
+            {' '}
+            <ButtonBack />
+          </div>
+        </div>
+      </div>
+    )
+    ) : (
+      (currentUser?.id == id) ? ( 
+        <div>
+        <div className="grid-container-show-user">
+          <div>
+            <Navbar />
+          </div>
+          <div className="flex-show-user">
+            <UserShow
+              name={currentUser?.name}
+              description={currentUser?.description}
+              rut={currentUser?.rut}
+              money={currentUser?.money}
+              email={currentUser?.email}
+            />
+            <ButtonUpdatingUser />
+            {' '}
+            <ButtonBack />
+          </div>
+        </div>
+      </div>
+    ) : (
+      <div>
       <div className="grid-container-show-user">
         <div>
           <Navbar />
         </div>
-        <div className="flex-show-user">
-          <UserShow
-            name={currentUser?.name}
-            description={currentUser?.description}
-            rut={currentUser?.rut}
-            money={currentUser?.money}
-            email={currentUser?.email}
-          />
-          <ButtonUpdatingUser />
-          {' '}
-          <ButtonBack />
-        </div>
+      <h1>No estás autorizado para ver el perfil de otra persona. </h1>
       </div>
-    </div>
-  );
-}
+      </div>
+    )
+   )
+  )
+};
 
 export default ShowUser;


### PR DESCRIPTION
## What?
-Se implementó código de control de flujo para permitir que el administrador pueda visualizar la vista del perfil de usuario de cada usuario de la plataforma, incluyéndolo a él.
-Se añadió un mensaje en la vista del perfil de un usuario para el caso en que un usuario, sin ser administrador de la plataforma, intenta ingresar al perfil de otro usuario.

## Why?
-Dado que el administrador podrá eliminar usuarios solamente desde la vista del perfil de un usuario en particular, añadir esta feature es relevante puesto que de esta manera se está facilitando regular el funcionamiento de la aplicación web, en el caso de que un usuario no esté cumpliendo con las normas de conducta de la plataforma (o términos y condiciones) y el administrador desee eliminarlo para el bien de la comunidad.

## How?
-El control de flujo se generó a partir de un operador ternario.
-Se tuvo que cambiar la ruta del perfil de un usuario. Antes era /profile, pero ahora como es necesario manejar el id del usuario del perfil (para el caso en que el administrador ingrese al perfil de otro usuario)
-Se tuvo que añadir una request de tipo get al endpoint /users/:id para el caso en que el currentUser es administrador de la aplicación, de tal forma de obtener la información del usuario con el id dado por la ruta.

## Testing? (almost required)
-Pending. Se testeó manualmente los distintos casos de control de flujo en la vista de perfil de un usuario en particular y se pudo notar que se renderizó la información correspondiente a cada caso respectivo del control de flujo.

## Screenshots (almost required in frontend)
![Captura de Pantalla 2022-06-07 a la(s) 19 03 21](https://user-images.githubusercontent.com/44145317/172498652-9c30a70d-4721-41b7-a527-83c0dffe8bd5.png)

