### PR TITLE
Fix(userShowView)

### DIFF
--- a/src/components/user/userShow/UserShow.css
+++ b/src/components/user/userShow/UserShow.css
@@ -1,5 +1,5 @@
 .card-profile {
-    height: 80%;
+    height: auto;
     background-color: rgba(131, 191, 226, 0.87);
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
     border-radius: 8px;
@@ -9,6 +9,7 @@
     border-style: solid;
     border-color: darkblue;
     border-width: 3px;
+    padding-bottom: 3vh;
 }
 
 .title-show-user {


### PR DESCRIPTION
## What?
- Se solucionó el problema de que las vista de show de un usuario no estaba siendo responsiva al hacer más pequeña la ventana del navegador. Cuando se hacía mas pequeña la ventana del navegador, los elementos del div de la tarjeta de la información del perfil, se salían de esté (desbordamiento de contenido)

## Why?
Necesario para lograr una interfaz de usuario responsiva, de tal forma de mejorar la experiencia de usuario.

## How?
- Se modificó el valor del atributo height en la className asociada a la tarjeta de la información del perfil (card-profile). Se modificó "height: 80%" por "height: auto". 
- También se modificó el padding-bottom para que la tarjeta con la información de perfil tuviera un mayor margen con su elemento ubicado más abajo (h3 de correo electrónico).

## Testing? (almost required)
Se testeó manualmente que el cambió en el CSS hiciera efectivamente lo que se buscaba.

## Screenshots (almost required in frontend)
![Captura de Pantalla 2022-06-22 a la(s) 16 46 44](https://user-images.githubusercontent.com/44145317/175134365-7ca9932c-3df5-4d27-b0de-1b5f565545c2.png)
![Captura de Pantalla 2022-06-22 a la(s) 16 47 07](https://user-images.githubusercontent.com/44145317/175134380-f18aea0c-82d1-427f-9c98-ebfbc4ff8e57.png)


