### PR TITLE
Fix(changeLanguae): Change language in list users

### DIFF
--- a/src/components/user/usersList/UsersList.jsx
+++ b/src/components/user/usersList/UsersList.jsx
@@ -38,9 +38,17 @@ function UsersList({ users, className }) {
                 {user.description}
               </li>
               <li className="accordion-body-list-rows">
-                Admin:
+                Administrador(a):
                 {' '}
-                {String(user.isAdmin)}
+                {user.isAdmin == true ? (
+                  <>
+                    Sí
+                  </>
+                ) : (
+                  <>
+                    No
+                  </>
+                )}
               </li>
               <br />
               <div className="display-flex-row">


### PR DESCRIPTION
## What?
-Se corrigió el idioma en la vista de list de users que estaba en inglés. La idea es que toda la página esté en el mismo idioma, que en este caso corresponde al español. Antes se mostraba true o false en el atributo admin. Ahora se muestra sí o no en el atributo administrador(a).

## Why?
-Para ser consistentes con el mismo idioma a utilizar en la aplicación.

## How?
-Por medio de control de flujo para ver si el admin estaba mostrándose true o false.

## Testing? (almost required)
-Testeo manual 

## Screenshots (almost required in frontend)
![Captura de Pantalla 2022-06-23 a la(s) 04 31 17](https://user-images.githubusercontent.com/44145317/175254329-807ff9a7-d4d8-49e4-a677-4f87cff4a1b4.png)


