### PR TITLE
feat(users & projects): Added line breaks display

### DIFF
--- a/src/components/project/projectList/ProjectList.css
+++ b/src/components/project/projectList/ProjectList.css
@@ -8,3 +8,6 @@
     background-color: lightblue;
 }
 
+.jump-breaks {
+    white-space: pre-wrap;
+}

--- a/src/components/project/projectList/ProjectList.jsx
+++ b/src/components/project/projectList/ProjectList.jsx
@@ -17,7 +17,7 @@ function ProjectList({
         <Card.Title>
           {title}
         </Card.Title>
-        <Card.Text>
+        <Card.Text className="jump-breaks">
           {description}
         </Card.Text>
         <Button className="more-details" variant="primary" href={`/projects/${id}`}>Ver en más detalle</Button>

--- a/src/components/project/projectShow/fullDescriptionOfProject/FullDescriptionOfProject.css
+++ b/src/components/project/projectShow/fullDescriptionOfProject/FullDescriptionOfProject.css
@@ -9,6 +9,7 @@
     padding-top: 2vh;
     padding-bottom: 2vh;
     text-align: left;
+    white-space: pre-wrap;
 }
 
 

--- a/src/components/project/registerProject/RegisterProjectForm.css
+++ b/src/components/project/registerProject/RegisterProjectForm.css
@@ -25,7 +25,6 @@
     vertical-align: middle;
 }
 
-
 .center-info-register-project {
     font-size: 2vh;
     border-style: solid;
@@ -35,6 +34,7 @@
     border-width: 0.3vh;
     border-color: darkblue;
     border-radius: 0.5vh;
+    white-space: pre-wrap;
 }
 
 .button-submit-register-project {

--- a/src/components/user/userForm/UserForm.css
+++ b/src/components/user/userForm/UserForm.css
@@ -26,6 +26,7 @@
     border-color: darkblue;
     border-radius: 0.5vh;
     flex-grow: 3;
+    white-space: pre-wrap;
 }
 
 

--- a/src/components/user/userForm/UserForm.css
+++ b/src/components/user/userForm/UserForm.css
@@ -60,3 +60,12 @@
     align-self: center;
     text-align: right;
 }
+
+.description-with-copy {
+    display: inline-grid;
+    padding-right: 1vw;
+}
+
+.copy-description {
+    font-size: 0.75vw;
+}

--- a/src/components/user/userForm/UserForm.jsx
+++ b/src/components/user/userForm/UserForm.jsx
@@ -1,3 +1,6 @@
+// Para silenciar al hacer copy to clipboard con un p
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 /* eslint-disable no-alert */
 /* eslint-disable no-mixed-operators */
 /* eslint-disable no-param-reassign */
@@ -262,7 +265,10 @@ function UserForm() {
             </div>
 
             <div className="label-form-user">
-              <label className="label-content-form-user" htmlFor="description">Descripción: </label>
+              <div className="description-with-copy">
+                <label className="label-content-form-user" htmlFor="description">Descripción: </label>
+                <p className="copy-description" type="button" onClick={navigator.clipboard.writeText(placeholders.description)}>Click para Copiar descripción previa</p>
+              </div>
               <Field className="center-info-register-user" name="description" type="text" as="textarea" placeholder={placeholders.description} />
               {errors.description && touched.description && (
                 <div className="error-form-user">{errors.description}</div>

--- a/src/components/user/userShow/UserShow.css
+++ b/src/components/user/userShow/UserShow.css
@@ -34,6 +34,7 @@
     border-width: 0.3vh;
     border-color: darkblue;
     border-radius: 0.5vh;
+    white-space: pre-wrap;
 }
 
 .center-info-picture{

--- a/src/components/user/usersList/UsersList.css
+++ b/src/components/user/usersList/UsersList.css
@@ -14,6 +14,9 @@
   width: 100%;
 }
 
+.accordion-body-list-rows {
+  white-space: pre-wrap;
+}
 .accordion-body-list-rows::before {
   content: '→ ';
 }


### PR DESCRIPTION
## What?
Se habilitaron los saltos de línea en descripciones y un clicable para copiar la descripción previa

## Why?
Porque es parte del valor que puede agregar a un texto y para evitar que el usuario pierda su descripción previa

## How?
Se cambiaron los CSS correspondientes y se habilitó una función onclick

## Testing? (almost required)
Se testeo manualmente supervisando que la visual correspondiera. Además, se testeo de que, al registrar un proyecto, este se mostrara en su show con los saltos de línea

## Screenshots (almost required in frontend)
Adición de saltos de línea en descripciones de proyecto y usuario
![imagen](https://user-images.githubusercontent.com/42228743/175474369-56bfd892-5258-4c3f-b3b5-680e1729738e.png)
![imagen](https://user-images.githubusercontent.com/42228743/175474378-a990758f-23dd-46ab-8267-efce30d5b524.png)
![imagen](https://user-images.githubusercontent.com/42228743/175474392-bdc0d048-ff2f-4231-959d-c74d54db6e15.png)
![imagen](https://user-images.githubusercontent.com/42228743/175474398-302427b5-b6f4-4d58-8b52-5a771fa7eec3.png)

Adición de clickeable para copiar la descripción previa
![imagen](https://user-images.githubusercontent.com/42228743/175482828-6e87b110-19bc-41b1-ba01-24b9b86cd34d.png)
