### PR TITLE
hotfix(style): Changed accordion style for x-long words

### DIFF
--- a/src/components/user/usersList/UsersList.css
+++ b/src/components/user/usersList/UsersList.css
@@ -16,6 +16,7 @@
 
 .accordion-body-list-rows {
   white-space: pre-wrap;
+  overflow: scroll;
 }
 .accordion-body-list-rows::before {
   content: '→ ';


### PR DESCRIPTION
## What?
Que cuando aparezcan palabras hiper largas dentro del acordion, estas no se salgan de el

## Why?
Porque se ve terrible y no debería ser así

## How?
Cambie el css para que hubiera un scroll en esos casos, pero un scroll del elemento en particular no mas 

## Testing? (almost required)
Testeo manual, cosa de que se viera y actuara como se espera

## Screenshots (almost required in frontend)
![imagen](https://user-images.githubusercontent.com/42228743/175579737-d530660e-7b9e-44c4-b73c-c47c3f3c61ea.png)


